### PR TITLE
Fix #24 - Replace # with - in filename

### DIFF
--- a/tasks/lib/photobox.js
+++ b/tasks/lib/photobox.js
@@ -77,7 +77,7 @@ PhotoBox.prototype.createDiffImages = function() {
     picture = picture.replace(
       /(http:\/\/|https:\/\/)/, '').replace( /(\/)|(\|)/g,
       '-'
-    );
+    ).replace( '#', '-' );
     this.grunt.log.writeln( 'started diff for ' + picture );
 
     var oldFileExists = this.grunt.file.exists(


### PR DESCRIPTION
The new # separator is not replace with - in the filename when comparing
